### PR TITLE
Fix compatibility for OS X Maverics.

### DIFF
--- a/Allkdic/Constants.swift
+++ b/Allkdic/Constants.swift
@@ -22,6 +22,8 @@
  SOFTWARE.
 */
 
+var NSAppKitVersionNumberInt: Int32 { return Int32(floor(NSAppKitVersionNumber)) }
+
 struct BundleInfo {
     static let Version = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString") as String
     static let Build = NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleVersion") as String

--- a/Allkdic/Controllers/AboutWindowController.swift
+++ b/Allkdic/Controllers/AboutWindowController.swift
@@ -154,8 +154,12 @@ class AboutWindowController: WindowController {
     func styleButton(button: NSButton) {
         button.setButtonType(.MomentaryPushInButton)
         button.bezelStyle = .RoundedBezelStyle
-        button.controlSize = .SmallControlSize
         button.font = NSFont.systemFontOfSize(NSFont.systemFontSizeForControlSize(.SmallControlSize))
+        if NSAppKitVersionNumberInt > NSAppKitVersionNumber10_9 {
+            button.controlSize = .SmallControlSize
+        } else if let cell = button.cell() as? NSButtonCell {
+            cell.controlSize = .SmallControlSize
+        }
     }
 
     override func showWindow(sender: AnyObject?) {

--- a/Allkdic/Controllers/ContentViewController.swift
+++ b/Allkdic/Controllers/ContentViewController.swift
@@ -180,7 +180,8 @@ public class ContentViewController: NSViewController {
         forFrame frame: WebFrame!) {
 
         let URLString = URL.absoluteString! as NSString
-        if !URLString.containsString("query=") && !URLString.containsString("q=") {
+        if URLString.rangeOfString("query=").location == NSNotFound
+            && URLString.rangeOfString("q=").location == NSNotFound {
             return
         }
 


### PR DESCRIPTION
`NSButton.controlSize` and `NSString.containsString()` introduced at OS X 10.10.
