### PR TITLE
영문 키보드가 아닐 때 웹뷰 단축키가 작동하지 않는 문제(#39)를 해결합니다.

### DIFF
--- a/Allkdic/Categories/WebView+Key.m
+++ b/Allkdic/Categories/WebView+Key.m
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#import "Allkdic-Swift.h"
 #import "WebView+Key.h"
 
 @implementation WebView (Key)
@@ -27,24 +28,24 @@
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent
 {
     if (theEvent.modifierFlags & NSCommandKeyMask) {
-        NSString *chars = theEvent.charactersIgnoringModifiers;
+        CGKeyCode keyCode = theEvent.keyCode;
 
-        if ([chars isEqualToString:@"a"]) {
+        if (keyCode == [KeyBinding keyCodeFormKeyString:@"a"]) {
             [self selectAll:self];
             return YES;
         }
 
-        if ([chars isEqualToString:@"x"]) {
+        if (keyCode == [KeyBinding keyCodeFormKeyString:@"x"]) {
             [self cut:self];
             return YES;
         }
 
-        if ([chars isEqualToString:@"c"]) {
+        if (keyCode == [KeyBinding keyCodeFormKeyString:@"c"]) {
             [self copy:self];
             return YES;
         }
 
-        if ([chars isEqualToString:@"v"]) {
+        if (keyCode == [KeyBinding keyCodeFormKeyString:@"v"]) {
             [self paste:self];
             return YES;
         }


### PR DESCRIPTION
#### 원인

`NSEvent`의 `charactersIgnoringModifiers`는 영문 키보드일 경우에만 영문자를 리턴하기 때문에 한글 키보드일 경우에는 작동하지 않는 문제가 있습니다.

#### 해결방법

key code를 직접 비교하여 검사합니다.

#### 관련된 이슈

- [#39] 한글일 때에 단축키 입력이 되지 않는 문제