### PR TITLE
Use `DictionaryType.inputFocusingScript` to focus on text input.

### DIFF
--- a/Allkdic/Controllers/ContentViewController.swift
+++ b/Allkdic/Controllers/ContentViewController.swift
@@ -148,8 +148,7 @@ public class ContentViewController: NSViewController {
     }
 
     public func focusOnTextArea() {
-        self.javascript("ac_input.focus()")
-        self.javascript("ac_input.select()")
+        self.javascript(DictionaryType.selectedDictionary.inputFocusingScript)
     }
 
 

--- a/DictionaryType.swift
+++ b/DictionaryType.swift
@@ -79,4 +79,11 @@ public enum DictionaryType: String {
         }
     }
 
+    public var inputFocusingScript: String {
+        switch self {
+        case .Naver: return "ac_input.focus(); ac_input.select()"
+        case .Daum: return "q.focus(); q.select()"
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #41