### PR TITLE
Fix a bug that all controls are disabled on OS X Mavericks.

### DIFF
--- a/Allkdic.xcodeproj/project.pbxproj
+++ b/Allkdic.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		030E7FB71B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.swift */; };
+		030E7FB71B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = 030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.m */; };
 		030E7FB81B3B2EB2009B3EB8 /* WebView+Key.m in Sources */ = {isa = PBXBuildFile; fileRef = 030E7FB41B3B2EB2009B3EB8 /* WebView+Key.m */; };
 		030E7FBA1B3B2F00009B3EB8 /* LoginItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E7FB91B3B2F00009B3EB8 /* LoginItem.swift */; };
 		030E7FBC1B3B3053009B3EB8 /* ApplicationFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030E7FBB1B3B3053009B3EB8 /* ApplicationFolder.swift */; };
@@ -88,7 +88,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSWindow+CanBecomeKeyWindow.swift"; sourceTree = "<group>"; };
+		030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSWindow+CanBecomeKeyWindow.m"; sourceTree = "<group>"; };
 		030E7FB31B3B2EB2009B3EB8 /* WebView+Key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WebView+Key.h"; sourceTree = "<group>"; };
 		030E7FB41B3B2EB2009B3EB8 /* WebView+Key.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WebView+Key.m"; sourceTree = "<group>"; };
 		030E7FB91B3B2F00009B3EB8 /* LoginItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginItem.swift; sourceTree = "<group>"; };
@@ -175,7 +175,7 @@
 				03CA9DA21B8C60D2000558EC /* AKHotKeyManager.m */,
 				030E7FBB1B3B3053009B3EB8 /* ApplicationFolder.swift */,
 				030E7FB91B3B2F00009B3EB8 /* LoginItem.swift */,
-				030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.swift */,
+				030E7FB21B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.m */,
 				030E7FB31B3B2EB2009B3EB8 /* WebView+Key.h */,
 				030E7FB41B3B2EB2009B3EB8 /* WebView+Key.m */,
 			);
@@ -463,7 +463,7 @@
 				030E7FB81B3B2EB2009B3EB8 /* WebView+Key.m in Sources */,
 				030E7FBA1B3B2F00009B3EB8 /* LoginItem.swift in Sources */,
 				0315897319FD4E0D002D5A7C /* AboutWindowController.swift in Sources */,
-				030E7FB71B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.swift in Sources */,
+				030E7FB71B3B2EB2009B3EB8 /* NSWindow+CanBecomeKeyWindow.m in Sources */,
 				0362B0CC19FD146B00C88610 /* PreferenceWindowController.swift in Sources */,
 				03CA9DA01B8C60BE000558EC /* PopoverController.swift in Sources */,
 				03CA9DA31B8C60D2000558EC /* AKHotKeyManager.m in Sources */,

--- a/Allkdic/Utils/NSWindow+CanBecomeKeyWindow.m
+++ b/Allkdic/Utils/NSWindow+CanBecomeKeyWindow.m
@@ -20,11 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Cocoa
+#import <Cocoa/Cocoa.h>
 
-extension NSWindow {
-    // NSPopover의 window가 Key Window가 될 수 있어야 popover 안에 있는 control들을 사용가능함.
-//    func canBecomeKeyWindow() -> Bool {
-//        return true
-//    }
+@implementation NSWindow (CanBecomeKeyWindow)
+
+- (BOOL)canBecomeKeyWindow {
+    return YES;
 }
+
+@end


### PR DESCRIPTION
- Add an extension to override `canBecomeKeyWindow` property on `NSWindow`.

![screen shot 2015-09-20 at 1 51 57 am](https://cloud.githubusercontent.com/assets/931655/9977215/3e8b682a-5f3a-11e5-8e92-bca88c17f421.png)
