### PR TITLE
Fix crash on launch on macOS 14 (Sonoma)

### DIFF
--- a/Allkdic/AppDelegate.swift
+++ b/Allkdic/AppDelegate.swift
@@ -5,7 +5,7 @@ import SwiftUI
 class AppDelegate: NSObject, NSApplicationDelegate {
   @objc private(set) static var shared: AppDelegate!
 
-  private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+  private var statusItem: NSStatusItem!
   private let popover = NSPopover()
   private var eventMonitor: Any?
   private var preferencesWindow: NSWindow?
@@ -18,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationDidFinishLaunching(_: Notification) {
     AppDelegate.shared = self
+    self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     self.setupStatusItem()
     self.setupPopover()
     self.setupEventMonitor()


### PR DESCRIPTION
## Summary

- Fix launch crash (`SIGABRT` in `CGSConnectionByID`) affecting all macOS 14.x (Sonoma) users.

## Problem

The app crashes immediately on launch on macOS 14.x — the status bar icon never appears and the app silently terminates. Confirmed by multiple crash reports from App Store Connect on macOS 14.6.1, 14.8.2, and 14.8.3.

**Crash stack trace:**
```
SIGABRT → __assert_rtn → CGSConnectionByID
  ← SLSRegisterConnectionNotifyProc
  ← +[NSCGSStatusItem addNavigationChangedNotificationHandler:]
  ← -[NSStatusItem _initWithStatusBar:length:priority:systemInsertOrder:]
  ← AppDelegate.init() (AppDelegate.swift:8)
  ← SwiftUI: FallbackDelegateBox.delegate.getter
  ← SwiftUI: runApp(_:)
```

## Root Cause

`NSStatusBar.system.statusItem(withLength:)` was called as a **property initializer** in `AppDelegate`, which runs during `init()`. On macOS 14.x, SwiftUI creates the `@NSApplicationDelegateAdaptor` before the window server (CGS) connection is established. `NSStatusItem` initialization requires a valid CGS connection to register notification handlers, causing an assertion failure → `abort()`.

On macOS 26, SwiftUI establishes the CGS connection earlier so this happened to work — but it was never safe to call during `init()`.

## Fix

Defer `NSStatusItem` creation from the property initializer to `applicationDidFinishLaunching`, where the CGS connection is guaranteed to be ready.

```diff
- private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+ private var statusItem: NSStatusItem!
```

```diff
  func applicationDidFinishLaunching(_: Notification) {
    AppDelegate.shared = self
+   self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
    self.setupStatusItem()
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash on macOS 14 (Sonoma) by creating the status bar item after the app finishes launching. Sonoma users can now start the app and see the menu bar icon.

- **Bug Fixes**
  - Defer NSStatusItem creation from a property initializer to applicationDidFinishLaunching to wait for a valid CGS connection and avoid SIGABRT in CGSConnectionByID.

<sup>Written for commit a10ae9f7cc51edfee36b805ccefa5036cf84484a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

