### PR TITLE
Fix Stage Manager window slide when closing popover

### DIFF
--- a/Allkdic/AppDelegate.swift
+++ b/Allkdic/AppDelegate.swift
@@ -82,7 +82,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   @objc func openPopover() {
     guard let button = statusItem.button else { return }
     self.statusItem.button?.state = .on
-    NSApp.activate(ignoringOtherApps: true)
     self.popover.show(relativeTo: .zero, of: button, preferredEdge: .maxY)
     NotificationCenter.default.post(name: .popoverDidOpen, object: nil)
   }


### PR DESCRIPTION
## Problem
When closing the Allkdic popover with the hotkey, windows from other
apps (e.g. Chrome) slide to the side stage in Stage Manager. This is
caused by `NSApp.activate(ignoringOtherApps: true)` in `openPopover()`,
which triggers Stage Manager to treat the app activation as a scene
switch. When the popover is then closed, Stage Manager animates the
transition back, making other windows appear to slide sideways.

## Solution
Removed `NSApp.activate(ignoringOtherApps:)` from `openPopover()`.
NSPopover shown relative to a status bar button works correctly without
activating the app, and Stage Manager no longer slides other windows.

## Testing
Tested with Stage Manager enabled on macOS 26.5. Chrome no longer
slides when opening/closing the Allkdic popover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Stage Manager from sliding other app windows when toggling the Allkdic status bar popover. Removed `NSApp.activate(ignoringOtherApps: true)` from `openPopover()` so showing the popover doesn’t trigger a scene switch.

<sup>Written for commit 0746a147780d58b5cf621814cc0ecb3602e0988c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/devxoul/allkdic/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

