### PR TITLE
Fix Naver/Daum login not syncing back to the in-app WebView

### DIFF
--- a/Allkdic/Views/DictionaryWebView.swift
+++ b/Allkdic/Views/DictionaryWebView.swift
@@ -57,12 +57,13 @@ private struct WebView: NSViewRepresentable {
   }
 
   @MainActor
-  class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+  class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     @Binding var isLoading: Bool
     var dictionary: DictionaryType
     var lastLoadedURL: String?
     weak var webView: WKWebView?
     private nonisolated(unsafe) var popoverObserver: NSObjectProtocol?
+    private var popupWindow: NSWindow?
 
     init(isLoading: Binding<Bool>, dictionary: DictionaryType) {
       _isLoading = isLoading
@@ -131,16 +132,50 @@ private struct WebView: NSViewRepresentable {
       self.lastLoadedURL = nil
     }
 
+    // Naver/Daum 로그인은 팝업 창(window.open)으로 뜨는데, 이걸 외부 브라우저로 보내면
+    // 로그인 세션 쿠키가 앱의 WKWebView 데이터스토어와 공유되지 않아 로그인이 반영되지 않는다.
+    // 전달받은 configuration을 그대로 재사용해 같은 데이터스토어를 쓰는 팝업 웹뷰를 앱 안에 띄운다.
     func webView(
       _: WKWebView,
-      createWebViewWith _: WKWebViewConfiguration,
-      for navigationAction: WKNavigationAction,
+      createWebViewWith configuration: WKWebViewConfiguration,
+      for _: WKNavigationAction,
       windowFeatures _: WKWindowFeatures,
     ) -> WKWebView? {
-      if let url = navigationAction.request.url {
-        NSWorkspace.shared.open(url)
-      }
-      return nil
+      self.popupWindow?.close()
+
+      let popupWebView = WKWebView(frame: NSRect(x: 0, y: 0, width: 480, height: 640), configuration: configuration)
+      popupWebView.navigationDelegate = self
+      popupWebView.uiDelegate = self
+
+      let window = NSWindow(
+        contentRect: popupWebView.frame,
+        styleMask: [.titled, .closable, .resizable],
+        backing: .buffered,
+        defer: false,
+      )
+      window.isReleasedWhenClosed = false
+      window.title = self.dictionary.title
+      window.contentView = popupWebView
+      window.delegate = self
+      window.center()
+      window.makeKeyAndOrderFront(nil)
+      NSApp.activate(ignoringOtherApps: true)
+
+      self.popupWindow = window
+      return popupWebView
+    }
+
+    // 로그인 완료 후 팝업이 스스로 닫힐 때(window.close()) 호출된다.
+    func webViewDidClose(_: WKWebView) {
+      self.popupWindow?.close()
+    }
+
+    // 팝업이 어떤 경로로든(로그인 완료, 사용자가 직접 닫기) 닫히면
+    // 로그인 세션이 반영되도록 메인 웹뷰를 새로고침한다.
+    func windowWillClose(_ notification: Notification) {
+      guard notification.object as? NSWindow === self.popupWindow else { return }
+      self.popupWindow = nil
+      self.webView?.reload()
     }
   }
 }


### PR DESCRIPTION
## Summary
- Login popups (e.g. Naver's login window) were opened in the system default browser via `NSWorkspace.shared.open`, which uses a completely separate cookie store from the app's WKWebView. Logging in there never propagated back to the app, so the dictionary view always showed a logged-out state.
- Popups are now presented in an in-app `NSWindow` backed by a `WKWebView` built from the exact `WKWebViewConfiguration` WebKit passes to `createWebViewWith(_:for:windowFeatures:)`, so the login session is written to the same data store the main dictionary view uses.
- When the popup closes (either via `window.close()` after a successful login, or the user closing it manually), the main dictionary WebView reloads to pick up the new session.

## Test plan
- [x] Built and ran locally via `tuist build` / running the Debug app
- [x] Manually verified: open the popover, click Naver's login button, log in inside the in-app popup window, confirm the popup closes and the main view shows a logged-in state
- [ ] Same check for Daum, if it has a similar login flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Naver/Daum login popups so sessions sync with the in-app `WKWebView`. Popups now open in an in-app window using the same `WKWebViewConfiguration`, and the main view reloads when the popup closes.

- **Bug Fixes**
  - Implemented `webView(_:createWebViewWith:for:windowFeatures:)` to show popups in an `NSWindow` with the provided `WKWebViewConfiguration`.
  - Added `NSWindowDelegate` handling to close the popup and reload the main web view (`windowWillClose`, `webViewDidClose`).
  - Removed external browser fallback using `NSWorkspace.shared.open`.

<sup>Written for commit 09728e012c48a9a3201d384fb720cb5244746d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/devxoul/allkdic/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

